### PR TITLE
Makes library minification safe

### DIFF
--- a/lib/deferred-with-update.js
+++ b/lib/deferred-with-update.js
@@ -13,7 +13,7 @@
 	// As such, we can define it as a service object and inject the $q class.
 	app.service(
 		"DeferredWithUpdate",
-		function( $q ) {
+		['$q', function( $q ) {
 
 
 			// I just pass-through to the core $q class.
@@ -173,7 +173,7 @@
 			};
 
 
-		}
+		}]
 	);
 
 


### PR DESCRIPTION
Your library wasn't minification safe, meaning it breaks when running something like Uglify on it. This pull request fixes this.

Thanks!
